### PR TITLE
Revision: case files

### DIFF
--- a/source/_static/css/nekrs.css
+++ b/source/_static/css/nekrs.css
@@ -1,3 +1,35 @@
 .wy-nav-content {
     max-width: 90% !important;
 }
+
+/* tall: increase height in table if content includes <p> */
+table.tall td p,
+table.tall td span,
+table.tall td li,
+table.tall td ul,
+table.tall td ol,
+table.tall td code,
+table.tall td pre {
+  line-height: 1.4 !important;
+}
+
+/* Sphinx sometimes renders forced breaks as line-blocks */
+table.tall td .line-block,
+table.tall td .line-block .line {
+  line-height: 1.4 !important;
+}
+
+/* If RTD wraps tables responsively, mirror the above selectors */
+.wy-table-responsive table.tall td,
+.wy-table-responsive table.tall th,
+.wy-table-responsive table.tall td p,
+.wy-table-responsive table.tall td span,
+.wy-table-responsive table.tall td li,
+.wy-table-responsive table.tall td ul,
+.wy-table-responsive table.tall td ol,
+.wy-table-responsive table.tall td code,
+.wy-table-responsive table.tall td pre,
+.wy-table-responsive table.tall td .line-block,
+.wy-table-responsive table.tall td .line-block .line {
+  line-height: 1.4 !important;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -46,6 +46,10 @@ extensions = ["sphinx.ext.mathjax",
               "sphinx.ext.githubpages", 
               "sphinx_mdinclude",
               "sphinx_tabs.tabs"]
+
+# Suppress Pygments “highlighting failure” warnings
+suppress_warnings = ['misc.highlighting_failure']
+
 numfig = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/index.rst
+++ b/source/index.rst
@@ -47,6 +47,13 @@ Table of Contents
 .. * :ref:`modindex`
 .. * :ref:`search`
 
+Versioning
+----------
+
+.. mdinclude:: _includes/README.md
+   :start-line: 72
+   :end-line: 74
+
 .. mdinclude:: _includes/README.md
    :start-line: 87
    :end-line: 108

--- a/source/other_resources.rst
+++ b/source/other_resources.rst
@@ -8,12 +8,14 @@ Other Resources
 Linear Algebra Functions (linAlg)
 ---------------------------------
 
+*TODO*
 
 .. _opsem:
 
 SEM operators (opSEM)
 ---------------------
 
+*TODO*
 
 .. _nek5000_tools:
 
@@ -48,4 +50,41 @@ Additional information about *Nek5000* tools can be found `here <https://nek5000
   The `genbox <https://nek5000.github.io/NekDoc/tools/genbox.html>`_ tool creates simple 2D and 3D meshes that can be used for both *Nek5000* and *NekRS* simulations. 
   For *NekRS* applications, this is most likely the only tool that be of use to most users. 
   Other *Nek5000* tools will be rarely used.
+
+
+.. _file_extensions:
+
+File Extensions
+---------------
+
+.. csv-table:: Case Files & Extensions
+   :header: "Extension","Name","Required?","Notes / Typical usage"
+   :widths: 20,30,20,30
+   :quote: "
+   :delim: ,
+
+   ".sess","NekNek sessions file","Yes (Only for NekNek)","See :ref:`sess_file`"
+   ".par","Main parameter file","Yes","See :ref:`par_file`"
+   ".udf","User-defined functions","Yes","See :ref:`udf_file`"
+   ".oudf","Extra OKL kernels file","No","See :ref:`okl_block`"
+   ".upd","Trigger file","No","See :ref:`upd_file`"
+
+   ".usr","Legacy Nek5000 user file","No","See :ref:`usr_file`"
+   ".re2","Mesh file","Yes","See :ref:`re2_file`"
+   ".co2","Legacy connectivity file","No","See `Nek5000 co2 example <https://nek5000.github.io/NekDoc/tutorials/multi_rans.html?highlight=co2#generating-connectivity-file-co2>`_"
+
+   ".yaml","YAML config file","No","Used for ``nekAscent.hpp`` in-situ visualization"
+
+.. csv-table:: Output Files & Extensions
+   :header: "Extension","Name","Notes / Typical usage"
+   :widths: 20,40,40
+   :quote: "
+   :delim: ,
+
+   "\*0.f0000","Nek format checkpoint file","0-based index. See :ref:`qstart_vis`"
+   ".nek5000","Nek format checkpoint metadata file", "See: ref: `_qstart_vis`"
+   ".bp/","ADIOS2 format checkpoint (folder)",""
+   ".log.*","Log files","From ``nrsbmpi``, suffixed by rank count and rollover to ``.log1``"
+   ".vtu/.vtk","VTK files","Mainly for particle data"
+
 

--- a/source/other_resources.rst
+++ b/source/other_resources.rst
@@ -6,7 +6,7 @@ Other Resources
 .. _linalg:
 
 Linear Algebra Functions (linAlg)
---------------------------------
+---------------------------------
 
 
 .. _opsem:

--- a/source/other_resources.rst
+++ b/source/other_resources.rst
@@ -82,7 +82,7 @@ File Extensions
    :delim: ,
 
    "\*0.f0000","Nek format checkpoint file","0-based index. See :ref:`qstart_vis`"
-   ".nek5000","Nek format checkpoint metadata file", "See: ref: `_qstart_vis`"
+   ".nek5000","Nek format checkpoint metadata file", "See :ref:`qstart_vis`"
    ".bp/","ADIOS2 format checkpoint (folder)",""
    ".log.*","Log files","From ``nrsbmpi``, suffixed by rank count and rollover to ``.log1``"
    ".vtu/.vtk","VTK files","Mainly for particle data"

--- a/source/other_resources.rst
+++ b/source/other_resources.rst
@@ -3,10 +3,22 @@
 Other Resources
 ===============
 
-.. _scripts:
+.. _linalg:
 
-Building the Nek5000 Tool Scripts
----------------------------------
+Linear Algebra Functions (linAlg)
+--------------------------------
+
+
+.. _opsem:
+
+SEM operators (opSEM)
+---------------------
+
+
+.. _nek5000_tools:
+
+Building the Nek5000 Tools
+--------------------------
 
 *NekRS* does not package the legacy toolkit available with :term:`Nek5000`, e.g., tools for creating or adapting meshes.
 It relies instead on the toolbox available with :term:`Nek5000`, which must be installed separately.
@@ -36,3 +48,4 @@ Additional information about *Nek5000* tools can be found `here <https://nek5000
   The `genbox <https://nek5000.github.io/NekDoc/tools/genbox.html>`_ tool creates simple 2D and 3D meshes that can be used for both *Nek5000* and *NekRS* simulations. 
   For *NekRS* applications, this is most likely the only tool that be of use to most users. 
   Other *Nek5000* tools will be rarely used.
+

--- a/source/problem_setup/boundary_conditions.rst
+++ b/source/problem_setup/boundary_conditions.rst
@@ -22,7 +22,7 @@ The boundary conditions are also shown below:
    :language: none
    :lines: 1-3, 154-182
 
-Assigning boundary condition types in *NekRS* is handled differently depending on if you are using a third-party meshing tool such as *GMSH*, *ICEM*, *Cubit*, etc. and importing the mesh with *Nek5000* :ref:`tool scripts <scripts>`, such as ``gmsh2nek``, ``exo2nek`` or ``cgns2nek``, or if you are using a mesh generated with a Nek-native tool, such as `Genbox <https://nek5000.github.io/NekDoc/tools/genbox.html?highlight=genbox>`_.
+Assigning boundary condition types in *NekRS* is handled differently depending on if you are using a third-party meshing tool such as *GMSH*, *ICEM*, *Cubit*, etc. and importing the mesh with *Nek5000* :ref:`tool scripts <nek5000_tools>`, such as ``gmsh2nek``, ``exo2nek`` or ``cgns2nek``, or if you are using a mesh generated with a Nek-native tool, such as `Genbox <https://nek5000.github.io/NekDoc/tools/genbox.html?highlight=genbox>`_.
 
 Boundary conditions are typically assigned in the :ref:`Parameter file <parameter_file>`.
 To setup cases that use third party meshes, where boundaries are identified by a unique integer or boundary ID, you will need to use the ``boundaryIDMap`` parameter in the ``MESH`` section to identify the mesh boundaries, which are then mapped to the desired boundary condition in field section using the ``boundaryTypeMap`` key.

--- a/source/problem_setup/boundary_conditions.rst
+++ b/source/problem_setup/boundary_conditions.rst
@@ -3,7 +3,7 @@
 Boundary conditions
 ===================
 
-Boundary conditions for each mesh boundary should normally be set in the :ref:`parameter_file`, using the ``boundaryTypeMap`` parameter.
+Boundary conditions for each mesh boundary should normally be set in the :ref:`par_file`, using the ``boundaryTypeMap`` parameter.
 This is used within the ``FLUID VELOCITY`` or ``SCALAR FOO`` sections to set the boundary conditions of the respective fields.
 
 Available Types
@@ -24,7 +24,7 @@ The boundary conditions are also shown below:
 
 Assigning boundary condition types in *NekRS* is handled differently depending on if you are using a third-party meshing tool such as *GMSH*, *ICEM*, *Cubit*, etc. and importing the mesh with *Nek5000* :ref:`tool scripts <nek5000_tools>`, such as ``gmsh2nek``, ``exo2nek`` or ``cgns2nek``, or if you are using a mesh generated with a Nek-native tool, such as `Genbox <https://nek5000.github.io/NekDoc/tools/genbox.html?highlight=genbox>`_.
 
-Boundary conditions are typically assigned in the :ref:`Parameter file <parameter_file>`.
+Boundary conditions are typically assigned in the :ref:`Parameter file <par_file>`.
 To setup cases that use third party meshes, where boundaries are identified by a unique integer or boundary ID, you will need to use the ``boundaryIDMap`` parameter in the ``MESH`` section to identify the mesh boundaries, which are then mapped to the desired boundary condition in field section using the ``boundaryTypeMap`` key.
 As an example, consider an inlet-outlet pipe flow, where three boundary conditions are applied to the mesh boundary IDs 389 (``udfDirichlet`` - inlet), 231 (``zeroNeumann`` - outlet), 4 (``zeroDirichlet`` - walls).
 The corresponding boundary condition assignment in ``.par`` file will be as follows,
@@ -155,7 +155,7 @@ The string field identifiers are:
 
 .. note::
 
-    The scalar field string identifiers are declared in :ref:`Parameter file <parameter_file>` under the :ref:`General Section<sec:generalpars>`.
+    The scalar field string identifiers are declared in :ref:`Parameter file <par_file>` under the :ref:`General Section<sec:generalpars>`.
 
 The boundary condition types that require inclusion of user defined functions in ``.udf`` file are shown in the following table:
 

--- a/source/problem_setup/case.rst
+++ b/source/problem_setup/case.rst
@@ -4,7 +4,8 @@ Case files
 ==========
 
 NekRS simulation requires a number of case definition files which are described in this page.
-An overview of these are presented in the image below .
+An overview of these are presented in the image below.
+See also :ref:`file_extensions` for summarized tables.
 
 .. _fig:case_overview:
 
@@ -32,7 +33,7 @@ Optionally, the user can also define the names of ``.udf``, ``.oudf`` and ``.usr
 The following sections describe the structure and syntax for each of these files for a general case.
 
 
-.. _parameter_file:
+.. _par_file:
 
 Parameter File (.par)
 ---------------------
@@ -44,6 +45,10 @@ Parameter File (.par)
    .. code-block:: bash
 
       nrsman par
+
+.. warning::
+
+   *nekRS* ``.par`` file is not compatible to *Nek5000* ``.par`` file.
 
 Most information about the problem setup is defined in the parameter (``.par``) file.
 This file is organized in a number of **sections**, each with a number of **keys**.
@@ -295,7 +300,7 @@ NekNek Parameters
    ``multirateTimeStepping``,"``true, false`` |br| ``+ correctorSteps=<int>``","Default = ``false`` |br| Outer corrector steps. Default is ``0``. Note: ``boundaryEXTOrder`` > 1 requires ``correctorSteps`` > 0 for stability"
 
 
-.. _udf_functions:
+.. _udf_file:
 
 User-Defined Host File (.udf)
 -----------------------------
@@ -487,7 +492,7 @@ Typical operations include:
   * Writing custom field files (*TODO*).
 
 
-.. _usr_functions:
+.. _usr_file:
 
 Legacy Nek5000 User File (.usr)
 --------------------------------
@@ -672,7 +677,7 @@ Then, all are converted from ``double`` to ``dfloat`` before copying to
    **Nek5000/NekRS sizes and offsets**
 
    - ``mesh->Nlocal``: number of local points on this rank
-     (e.g., ``lx1*ly1*lz1*nelv``; fluid+solid mesh uses``nelt``).
+     (e.g., ``lx1*ly1*lz1*nelv``; fluid+solid mesh uses ``nelt``).
 
    - ``fieldOffset``: padded device stride (alignment + max local size).
      It is **not** equal to ``lx1*ly1*lz1*lelv``.
@@ -684,6 +689,7 @@ Then, all are converted from ``double`` to ``dfloat`` before copying to
    Use ``fieldOffset``/``fieldOffsetSum`` for declaring multi-component device
    arrays and indexing. Use ``Nlocal`` for loop lengths and buffer sizes.
 
+.. _re2_file:
 
 Mesh File (.re2)
 ----------------
@@ -738,12 +744,12 @@ nekRS requires that the flow mesh be a subset of the heat transfer mesh. In othe
 the flow mesh always has less than (or equal to, for cases without conjugate heat transfer)
 the number of elements in the heat transfer mesh. Creating a mesh for conjugate heat
 transfer problems requires additional pre-processing steps that are described in the
-:ref:`Creating a Mesh for Conjugate Heat Tranfser <cht_mesh>` section. The remainder
+:ref:`Creating a Mesh for Conjugate Heat Tranfser <meshing_cht>` section. The remainder
 of this section describes how to generate a mesh in ``.re2`` format, assuming
 any pre-processing steps have been done for the special cases of conjugate heat transfer.
 
 
-.. _session_file:
+.. _sess_file:
 
 NekNek Session File (.sess)
 ---------------------------
@@ -768,7 +774,7 @@ equal the total MPI ranks requested. Here is the ``eddyNekNek.sess`` example:
    it’s often best to make each session’s MPI ranks a multiple of 4.
 
 
-.. _trigger_file:
+.. _upd_file:
 
 Trigger Files (.upd)
 --------------------

--- a/source/problem_setup/case.rst
+++ b/source/problem_setup/case.rst
@@ -792,10 +792,24 @@ equal the total MPI ranks requested. Here is the ``eddyNekNek.sess`` example:
 
 .. _upd_file:
 
-Trigger Files (.upd)
---------------------
+Trigger File (nekrs.upd)
+------------------------
 
-**TODO** Full description
+The trigger file lets you change selected parameters **at runtime** so you can
+adjust a simulation without killing the job. Before launching, set a catchable
+signal in ``NEKRS_SIGNUM_UPD`` (see :ref:`nekrs_signal`). At runtime, write the
+requested options in ``nekrs.upd`` under the case directory. Accepted keys include:
 
-Allows modifications to the simulation during execution.
-Can be edited and then notify of changes through sending a signal MPI rank 0.
+.. code-block:: ini
+
+   checkpoint = true
+
+   [GENERAL]
+   endTime = 10.0
+   numSteps = 10000
+   writeinterval = 1.0
+
+When *NekRS* receives the configured signal, it reloads ``nekrs.upd`` and applies
+the changes on the next timestep. You can trigger this multiple times during a
+run.
+

--- a/source/problem_setup/case.rst
+++ b/source/problem_setup/case.rst
@@ -707,7 +707,7 @@ You can obtain ``.re2`` by
 
 There are three main limitations for the *nekRS* mesh:
 
-* **3D hexonly**: meshes must be hexahedral and three-dimensional.
+* **3D hex only**: meshes must be hexahedral and three-dimensional.
 * **Contiguous boundary IDs**: face boundary IDs must be 1, 2, 3, … without gaps.
 * **Element types**: supported are HEX8 and HEX20.
 

--- a/source/problem_setup/case.rst
+++ b/source/problem_setup/case.rst
@@ -27,7 +27,7 @@ Some optional files can also be included:
   (See :ref:`overlapping_overset_grids` tutorial).
 
 The case name is the default prefix applied to these files - for instance, a complete input description with a case name of "eddy" would be given by the files ``eddy.par``, ``eddy.re2``, ``eddy.udf``.
-Optionally, the user can also define the names of ``.udf``, ``.oudf`` and ``.usr`` in the :ref:`sec:generalpars` section and name of ``.re2`` file in :ref:`sec:meshpars` section of ``.par`` file. 
+Optionally, the user can also define the names of ``.udf``, ``.oudf`` and ``.usr`` in the :ref:`sec:generalpars` section and name of ``.re2`` file in :ref:`sec:meshpars` section of ``.par`` file.
 
 The following sections describe the structure and syntax for each of these files for a general case.
 
@@ -74,7 +74,7 @@ The valid sections for setting up a *NekRS* simulation are:
 
   * ``FLUID VELOCITY``: settings for the velocity solver
 
-  * ``FLUID PRESSURE``: settings for the pressure solver 
+  * ``FLUID PRESSURE``: settings for the pressure solver
 
   * ``SCALAR``: default scalar settings
 
@@ -83,7 +83,7 @@ The valid sections for setting up a *NekRS* simulation are:
 * ``BOOMERAMG``: settings for the Hypre's :term:`AMG` solver
 * ``NEKNEK``: settings for the *NekNek* module in *NekRS* (see :ref:`NekNek Parameters <sec:neknekpars>`)
 * ``CVODE``: settings for the CVODE solver (see :ref:`CVODE Parameters <sec:cvodepars>`)
-  
+
 .. note::
 
   - Section name and key/value pairs are case insensitive
@@ -135,12 +135,12 @@ General Parameters
    ``elapsedTime``,``<float>``,"Simulation time in wall clock minutes"
    ``dt``,``<float>`` |br| ``+ targetCFL = <float>`` |br| ``+ max = <float>`` |br| ``+ initial = <float>`` , "Time step size |br| adjust ``dt`` to match ``targetCFL`` |br| max limit of ``dt`` |br| Initial ``dt`` "
    ``advectionSubCyclingSteps``,``<int>``,"Number of OIFS sub-steps for advection |br| Default = ``0`` (OIFS turned off)"
-   ``constFlowRate``,"``meanVelocity = <float>`` |br| ``meanVolumetricFlow = <float>`` |br| ``+ direction = <X,Y,Z>``","Specifies constant flow velocity |br| Specifies constant volumetric flow rate |br| Specifies flow direction" 
+   ``constFlowRate``,"``meanVelocity = <float>`` |br| ``meanVolumetricFlow = <float>`` |br| ``+ direction = <X,Y,Z>``","Specifies constant flow velocity |br| Specifies constant volumetric flow rate |br| Specifies flow direction"
    ``scalars``,"``<string>, <string> ...``","Name of scalar fields to be solved"
    ``checkPointEngine``,``<string>`` |br| ``nek`` / ``adios``,"Specifies engine to write field files |br| Default = ``nek``"
    ``checkPointPrecision``,``<int>`` |br| ``32`` / ``64``,"Specifies precision of field files |br| Default = ``32``"
    ``checkPointControl``,``steps`` / ``simulationTime``,"Specifies check point frequency control type |br| Default = ``steps``"
-   ``checkPointInterval``,``<int>`` / ``<float>`` |br| 0 |br| -1, "Specifies check point frequency (``<int>`` for ``steps`` / ``<float>`` for ``simulationTime``) |br| ``0`` implies at end of simulation |br| ``-1`` disables checkpointing" 
+   ``checkPointInterval``,``<int>`` / ``<float>`` |br| 0 |br| -1, "Specifies check point frequency (``<int>`` for ``steps`` / ``<float>`` for ``simulationTime``) |br| ``0`` implies at end of simulation |br| ``-1`` disables checkpointing"
    ``udf``,"``""<string>""``","Optional name of user-defined host function file |br| Default is ``<case>.udf``"
    ``oudf``,"``""<string>""``","Optional name of user-defined OCCA kernel function file |br| As a default *NekRS* expects these are defined in :ref:`OKL block <okl_block>` in ``.udf`` file"
    ``usr``,"``""<string>""``","Optional name of user-defined legacy *Nek5000* (fortran) function file |br| Default is ``<case>.usr``"
@@ -207,7 +207,7 @@ Some specific field keys are shown below:
    :widths: 20,20,60
    :class: tall
    :header: Key, Value(s), Description/Note(s)/Default Value
-  
+
    ``density`` / ``rho``,``<float>``, "Fluid density"
    ``viscosity`` / ``mu``,``<float>``, "Fluid dynamic viscosity"
 
@@ -218,7 +218,7 @@ Some specific field keys are shown below:
    :widths: 20,20,60
    :class: tall
    :header: Key, Value(s), Description/Note(s)/Default Value
-  
+
    ``mesh``,``fluid`` |br| ``+ solid``, "Specifies the mesh region where scalar ``FOO`` is solved (relevant to :term:`CHT` case) |br| Default = ``fluid``"
    ``transportCoeff``,``<float>``, "Transport property for the scalar ``FOO`` (e.g., :math:`\rho c_p` for ``TEMPERATURE``) in the ``fluid`` ``mesh``"
    ``diffusionCoeff``,``<float>``, "Diffusion coefficient for the scalar ``FOO`` (e.g., :math:`k` for ``TEMPERATURE``) in the ``fluid`` ``mesh``"
@@ -246,7 +246,7 @@ These are to be included in the ``.par`` file under appropriate section for ``FL
    :class: tall
    :header: Key, Value(s), Description/Note(s)/Default Value
 
-   ``solver``,"``none`` |br| ``user`` |br| ``cvode`` |br| ``CG`` |br| ``+ combined`` |br| ``+ block`` |br| ``+ flexible`` |br| ``+ maxiter=<int>`` |br| ``GMRES`` |br| ``+ flexible`` |br| ``+ maxiter=<int>`` |br| ``+ nVector=<int>`` |br|  ``+ iR``","Solve off |br| user-specified |br| CVODE solver (see :ref:`sec:cvodepars`) |br| Conjugate gradient solver. **Default solver for velocity and scalar equation** |br| **Default for scalar equation** |br| **Default velocity solver** |br| . |br| . |br| . |br| Generalized Minimal Residual solver. **Default solver for pressure** |br| **Default for pressure** |br| . |br| Dimension of Krylov space |br| Iterative refinment "  
+   ``solver``,"``none`` |br| ``user`` |br| ``cvode`` |br| ``CG`` |br| ``+ combined`` |br| ``+ block`` |br| ``+ flexible`` |br| ``+ maxiter=<int>`` |br| ``GMRES`` |br| ``+ flexible`` |br| ``+ maxiter=<int>`` |br| ``+ nVector=<int>`` |br|  ``+ iR``","Solve off |br| user-specified |br| CVODE solver (see :ref:`sec:cvodepars`) |br| Conjugate gradient solver. **Default solver for velocity and scalar equation** |br| **Default for scalar equation** |br| **Default velocity solver** |br| . |br| . |br| . |br| Generalized Minimal Residual solver. **Default solver for pressure** |br| **Default for pressure** |br| . |br| Dimension of Krylov space |br| Iterative refinment"
    ``residualTol``,"``<float>`` |br| ``+ relative=<float>``","absolute linear solver residual tolerance. Default = ``1e-4`` |br| use absolute/relative residual (whatever is reached first)"
    ``absoluteTol``,"``<float>``","absolute solver tolerance (for CVODE only) |br| Default = ``1e-6``"
    ``initialGuess``,"``previous`` |br| ``extrapolation`` |br| ``projection`` |br| ``projectionAconj`` |br| ``+ nVector=<int>``", ". |br| **Default for velocity and scalars** |br| . |br| Defaults for pressure |br| dimension of projection space"
@@ -293,7 +293,7 @@ NekNek Parameters
 
    ``boundaryEXTOrder``,``<int>``, "Boundary extrapolation order |br| Default = ``1``. >1 may require additional corrector steps"
    ``multirateTimeStepping``,"``true, false`` |br| ``+ correctorSteps=<int>``","Default = ``false`` |br| Outer corrector steps. Default is ``0``. Note: ``boundaryEXTOrder`` > 1 requires ``correctorSteps`` > 0 for stability"
-   
+
 
 .. _udf_functions:
 
@@ -359,33 +359,32 @@ and can be launched from UDF host code directly as a regular function.
 
 .. code-block:: cpp
 
+   // -------- Device side (inside the OKL block) --------
+   #ifdef __okl__
 
-  // -------- Device side (inside the OKL block) --------
-  #ifdef __okl__
+   @kernel void my_exact(const dlong Ntotal,
+                         @ restrict const dfloat *X,
+                         @ restrict dfloat *U)
+   {
+     for (dlong n = 0; n < Ntotal; ++n; @tile(p_blockSize, @outer, @inner)) {
+       if (n < Ntotal) {
+         U[n] = sin(X[n]);
+       }
+     }
+   }
 
-  @kernel void my_exact(const dlong Ntotal,
-                        @ restrict const dfloat *X,
-                        @ restrict dfloat *U)
-  {
-    for (dlong n = 0; n < Ntotal; ++n; @tile(p_blockSize, @outer, @inner)) {
-      if (n < Ntotal) {
-        U[n] = sin(X[n]);
-      }
-    }
-  }
+   #endif
 
-  #endif
-
-  // -------- Host side (UDF code) --------
-  {
-    auto mesh = nrs->meshV;
-    deviceMemory<dfloat> o_tmp(mesh->Nlocal);
-    my_exact(o_tmp.size(), mesh->o_x, o_tmp); // o_tmp = sin(x)
-  }
+   // -------- Host side (UDF code) --------
+   {
+     auto mesh = nrs->meshV;
+     deviceMemory<dfloat> o_tmp(mesh->Nlocal);
+     my_exact(o_tmp.size(), mesh->o_x, o_tmp); // o_tmp = sin(x)
+   }
 
 .. tip::
 
-  If the user-defined functions are sufficiently large, it is conventional practice to write them in a ``.oudf`` file which is included within the ``ifdef`` block instead of the functions in the ``.udf`` file, as follows:
+   If the user-defined functions are sufficiently large, it is conventional practice to write them in a ``.oudf`` file which is included within the ``ifdef`` block instead of the functions in the ``.udf`` file, as follows:
 
   .. code-block:: c++
 
@@ -397,10 +396,10 @@ and can be launched from UDF host code directly as a regular function.
 
 .. tip::
 
-  Many common operations are available in ``platform->linAlg`` and ``opSEM``
-  (e.g., fills, axpby, dot products, norms, gradient, divergence). Prefer these
-  utilities over writing custom kernels when possible. See :ref:`linalg` and
-  :ref:`opsem` for details.
+   Many common operations are available in ``platform->linAlg`` and ``opSEM``
+   (e.g., fills, axpby, dot products, norms, gradient, divergence). Prefer these
+   utilities over writing custom kernels when possible. See :ref:`linalg` and
+   :ref:`opsem` for details.
 
 .. _udf_setup0:
 
@@ -477,7 +476,7 @@ UDF_ExecuteStep
 
 ``UDF_ExecuteStep`` offers the most flexibility. It is called once just before
 time marching begins, and then once **per time step**. The routine receives the
-current time (``double t``) and the step index (``int tstep``). 
+current time (``double t``) and the step index (``int tstep``).
 Typical operations include:
 
 * Run time-averaging updates (see *TODO*)
@@ -493,96 +492,105 @@ Typical operations include:
 Legacy Nek5000 User File (.usr)
 --------------------------------
 
-*NekRS* provides an optional framework for legacy interface with the *Nek5000* code, allowing access to fortran 77 based *Nek5000* user routines to perform custom operations.
-The user has the option to include ``<case>.usr`` in the case directory to include the usual *Nek5000* user routines. 
-For users unfamiliar with *Nek5000* code, more information can be found in `Nek5000 documentation <https://nek5000.github.io/NekDoc/>`_.
-Note that not all *Nek5000* routines are called by *NekRS*. 
-More commonly, the user may require call to the ``userchk()`` routine in *Nek5000* for post-processing operations. 
-If required, it must be explicitly called from ``.udf`` file as shown below:
+NekRS includes an optional legacy interface to *Nek5000* so you can reuse
+Fortran-77 user routines. If ``<case>.usr`` is present in the case directory,
+the file is compiled and linked, though not all *Nek5000* user subroutines are
+invoked by NekRS.
+
+Many one-time setup routines are still honored so existing *Nek5000* settings can
+be carried over. Users can continually use subroutines
+``usrdat0``, ``usrdat``, ``usrdat2``, ``usrdat3``, ``usrsetvert`` and ``useric``
+to modify mesh geometry, tag boundary surfaces, adjust connectivity and set initial
+conditions.
+Compute intensive subroutines such as ``userbc``, ``userf``, ``userq`` and ``uservp``
+are **not** used by *NekRS*. Users need to convert them into UDF or OKL implementation.
+
+The ``userchk`` is **not** called automatically. If needed, call it manually
+from UDF (e.g., ``UDF_ExecuteStep``) for post-processing or other setup tasks,
+for example:
 
 .. code-block:: c++
 
    void UDF_ExecuteStep(double time, int tstep)
    {
-     if(nrs->checkpointStep) {
-        nrs->copyToNek(time, tstep);
-        nek::userchk();
+     if(nrs->checkpointStep) { // occasionally call when a checkpoint step
+        nrs->copyToNek(time, tstep); // push device field to Nek5000 arrays
+        nek::userchk();              // call userchk in .usr
+        nrs->copyFromNek(time);      // only if userchk modify solutions
      }
    }
 
-For most applications, the ``userchk`` routine will be called from ``UDF_ExecuteStep`` function, likely for post-processing operations.
-``nrs->copyToNek`` copies all solution fields from :term:`OCCA` arrays to *Nek5000* (fortran) arrays. 
-This call is necessary before calling ``nek::userchk`` in order for the user to perform any post-processing on field arrays in *Nek5000*.
+.. note::
 
-.. warning::
+   - ``nrs->copyToNek`` copies all solution fields from :term:`OCCA` device arrays
+     to *Nek5000* (Fortran) host arrays. Use it only when ``nek::userchk``
+     needs current solutions.
+   - This transfer is expensive. Wrap the call under a suitable condition to
+     avoid excessive overhead.
+   - Call ``nrs->copyFromNek`` only if the legacy routine modifies solution
+     data that must be synchronized back to the device.
 
-   The ``nrs->copyToNek`` call performs expensive operation of copying the data from :term:`OCCA` arrays to Nek5000.
-   This must be done sparingly, only at certain time steps in the simulation.
-   Remember to call this routine within suitable ``if`` condition block.
-   As shown in the example above, ``nrs->copyToNek`` and ``nek::userchk`` are called only at ``checkPointStep``.
-
-Details on *Nek5000* ``.usr`` file can be found `here <https://nek5000.github.io/NekDoc/problem_setup/usr_file.html#user-routines-file-usr>`_ and specific information on ``userchk`` fortran routine `here <https://nek5000.github.io/NekDoc/problem_setup/usr_file.html#userchk>`_.
-
-Other *Nek5000* user routines that are internally called by *NekRS* during initialization are ``usrdat0``, ``usrdat``, ``usrdat2`` and ``usrdat3``.
-Details on these initialization routines can be found `here <https://nek5000.github.io/NekDoc/problem_setup/usr_file.html#initialization-routines>`_.
-These routines can be optionally used for specifying boundary conditions, mesh manipulation, parameter specification or other initialization operations. 
+For background on Nek5000, see the `Nek5000 documentation <https://nek5000.github.io/NekDoc/>`_.
+Details on these initialization routines are documented `here <https://nek5000.github.io/NekDoc/problem_setup/usr_file.html#initialization-routines>`_.
+To migrate a case, follow the *TODO* tutorial to converting a *Nek5000* case to
+*NekRS*.
+In this section, we focus one the interface for referencing variables between
+``.udf`` and ``.usr``.
 
 Legacy Data Interface
 """""""""""""""""""""
 
-*NekRS* provides an in-built mechanism to pass variables or array pointers to share data between *Nek5000* and *NekRS* through ``nekrs_registerPtr`` fortran routine.
-Consider the following code snippet in ``.usr`` file:
+NekRS does not “send” values or arrays to *Nek5000*. Instead, it shares them by
+**registering pointers**. On the Fortran side, any variable or array you expose
+must have a stable address, so put it in a ``COMMON`` block or give it the
+``SAVE`` attribute.
+Use the Fortran routine ``nekrs_registerPtr`` to register variables/arrays so
+NekRS can reference them by a string key.
+
+Here is an example ``.usr`` file:
 
 .. code-block:: fortran
 
-   subroutine userchk()
-   include 'SIZE'
-   include 'TOTAL'
+   c-----------------------------------------------------------------------
+         subroutine usrdat0
+         real gamma
+         save gamma
 
-   common /exact/ uexact(lx1,ly1,lz1,lelt*3),
-  &               texact(lx1,ly1,lz1,lelt) 
+         gamma = 1.4
 
-   real uexact, texact
+         call nekrs_registerPtr('gamma', gamma)
 
-   call computeexact(uexact, texact)
+         return
+         end
+   c-----------------------------------------------------------------------
+         subroutine userchk()
+         include 'SIZE'
+         include 'TOTAL'
 
-   call nekrs_registerPtr('uexact', uexact)
-   call nekrs_registerPtr('texact', texact)
+         common /exact/ uexact(lx1,ly1,lz1,lelt*3),
+        &               texact(lx1,ly1,lz1,lelt)
 
-   return
-   end
+         real uexact, texact
 
-   subroutine computeexact(uexact, texact)
-   include 'SIZE'
-   include 'TOTAL'
+         call nekrs_registerPtr('uexact', uexact(1,1,1,1,1))
+         call nekrs_registerPtr('vexact', uexact(1,1,1,1,2))
+         call nekrs_registerPtr('wexact', uexact(1,1,1,1,3))
+         call nekrs_registerPtr('texact', texact)
 
-   ! Code to compute exact solution
+         ! update uexact/texact here
 
-   return
-   end
+         return
+         end
 
-   subroutine usrdat0
+In this example, ``COMMON /exact/`` block holds two arrays store exact solutions
+(e.g., velocity and temperature). We register the **first-element addresses** of
+each velocity components and of temperature with ``nekrs_registerPtr`` inside
+``userchk``. The scalar ``gamma`` is registered in ``usrdat0`` and kept alive
+with ``SAVE``. Any data you register must be in a ``COMMON`` block or ``SAVE``
+so its address remains valid.
 
-   real gamma 
-   save gamma
-
-   gamma = 1.4
-
-   call nekrs_registerPtr('gamma', gamma)
-
-   return
-   end
-
-In the above code, two routines are defined in the fortran common block ``exact`` to store exact solution for velocity and temperature.
-The exact solutions are computed in ``userchk`` and the array pointers for the solutions are registered using ``nekrs_registerPtr`` subroutine.
-It takes two arguments - a string identifier for the pointer and the pointer to the array to be registered. 
-(Note that pointer to the first memory location in the array is registered).
-It is critical that these arrays are declared in fortran common block or that they are saved for them to be visible globally.
-Another example is shown with a variable, ``gamma``, in ``usrdat0`` routine, which is also registered in a similar manner.
-Note that the variable ``gamma`` is made static (or saved in memory) using the ``save`` command. 
-
-These pointers can now be accessed in ``.udf`` file and used to transfer data between *NekRS* and *Nek5000*.
-Example usage in ``.udf`` is shown below:
+These pointers can then be looked up in the ``.udf`` and used to exchange data
+between *NekRS* and *Nek5000*. Example usage in ``.udf``:
 
 .. code-block:: c++
 
@@ -590,40 +598,92 @@ Example usage in ``.udf`` is shown below:
 
    void UDF_Setup0(MPI_Comm comm, setupAide &options)
    {
-      gamma = *nek::ptr<double>("gamma"); 
+     gamma = *nek::ptr<double>("gamma");
    }
 
    void UDF_LoadKernels(deviceKernelProperties& kernelInfo)
    {
-      kernelInfo.define("p_GAMMA") = gamma;
+     kernelInfo.define("p_GAMMA") = gamma;
    }
 
    void UDF_ExecuteStep(double time, int tstep)
    {
-      if(nrs->lastStep) {
-        auto mesh = nrs->meshV;
+     if (nrs->lastStep) {
+       auto mesh = nrs->meshV;
+       auto Nlocal = mesh->Nlocal;
 
-        nek::userchk();
+       nek::userchk(); // compute exact solutions in .usr
 
-        std::vector<double> uexact(nek::ptr<double>("uexact"), nek::ptr<double>("uexact") + nrs->fluid->fieldOffsetSum);
-        std::vector<double> texact(nek::ptr<double>("texact"), nek::ptr<double>("texact") + mesh->Nlocal);
+       // Host pointers exported from usr
+       auto *u_ex = nek::ptr<double>("uexact");
+       auto *v_ex = nek::ptr<double>("vexact");
+       auto *w_ex = nek::ptr<double>("wexact");
 
-        auto o_uexact = platform->device.malloc<dfloat>(nrs->fluid->fieldOffsetSum);
-        auto o_texact = platform->device.malloc<dfloat>(nrs->fluid->fieldOffset);
+       // Range constructor (copy values into std::vector)
+       std::vector<double> t_ex(nek::ptr<double>("texact"),
+                                nek::ptr<double>("texact") + Nlocal);
 
-        o_uexact.copyFrom(uexact);
-        o_texact.copyFrom(texact);
+       // Host buffer
+       std::vector<dfloat> uexact(Nlocal), uexact(Nlocal), wexact(Nlocal), texact(Nlocal);
 
-        //compute error here...
-      }
+       // Convert from double to dfloat
+       for (int i = 0; i < Nlocal; i++) {
+         u_exact[i] = static_cast<dfloat>(u_ex[i]);
+         v_exact[i] = static_cast<dfloat>(v_ex[i]);
+         w_exact[i] = static_cast<dfloat>(w_ex[i]);
+         t_exact[i] = static_cast<dfloat>(t_ex[i]);
+       }
+
+       // Device buffer
+       auto o_uexact = platform->device.malloc<dfloat>(nrs->fluid->fieldOffsetSum);
+       auto o_texact = platform->device.malloc<dfloat>(Nlocal);
+
+       // copyFrom(src pointer, count, dest offset, src offset)
+       o_uexact.copyFrom(uexact.data(), Nlocal, 0 * nrs->fluid->fieldOffset, 0);
+       o_uexact.copyFrom(vexact.data(), Nlocal, 1 * nrs->fluid->fieldOffset, 0);
+       o_uexact.copyFrom(wexact.data(), Nlocal, 2 * nrs->fluid->fieldOffset, 0);
+       o_texact.copyFrom(texact.data(), Nlocal);
+
+       //compute error here...
+     }
    }
 
-As shown, ``nek::ptr`` stores the registered pointers, which is recognised using the string identifier specified in ``.usr`` file.  
-In ``UDF_Setup0`` the value referenced by the pointer corresponding to ``gamma`` is assigned to the C++ static variable of the same name.
-It is later used to define a kernel macro in ``UDF_LoadKernels`` as shown.
-Similarly, the pointers to fortran arrays identified by ``uexact`` and ``texact`` are used to copy data onto ``std::vector`` containers of the same name.
-The arrays are then copied from ``std::vector`` containers to :term:`OCCA` arrays ``o_uexact`` and ``o_texact``.
-The user can then perform any required operations on these arrays, such as compute solution error norms.
+As shown, ``nek::ptr`` returns the registered pointers by the string keys
+defined in the ``.usr`` file. In ``UDF_Setup0``, the value referenced by
+``gamma`` is read into a C++ static and later exported as a device macro in
+``UDF_LoadKernels``.
+
+For the arrays (``uexact``, ``vexact``, ``wexact``, ``texact``), we show two ways:
+use a raw host pointer from ``nek::ptr<double>(...)`` for velocity components
+and use a range constructor to make a copy into ``std::vector`` for temperature.
+Then, all are converted from ``double`` to ``dfloat`` before copying to
+:term:`OCCA` arrays.
+
+.. note::
+
+   *NekRS* compiles Fortran ``real`` as ``real*8`` (i.e., C++ ``double``).
+   In *NekRS*, ``dfloat`` may be ``double`` (default) or ``float`` (FP32 mode).
+   Converting on the host as shown works for both settings. If you always run in
+   FP64, you can skip the cast. Alternatively, you can convert on device via
+   ``platform->copyDoubleToDfloatKernel``.
+
+.. note::
+
+   **Nek5000/NekRS sizes and offsets**
+
+   - ``mesh->Nlocal``: number of local points on this rank
+     (e.g., ``lx1*ly1*lz1*nelv``; fluid+solid mesh uses``nelt``).
+
+   - ``fieldOffset``: padded device stride (alignment + max local size).
+     It is **not** equal to ``lx1*ly1*lz1*lelv``.
+
+   - ``fieldOffsetSum``: sum of component strides. |br|
+     For velocity: ``fieldOffsetSum = 3 * fieldOffset``. |br|
+     For scalar, ``fieldOffsetSum = nrs->Nscalar * fieldOffset``.
+
+   Use ``fieldOffset``/``fieldOffsetSum`` for declaring multi-component device
+   arrays and indexing. Use ``Nlocal`` for loop lengths and buffer sizes.
+
 
 Mesh File (.re2)
 ----------------
@@ -701,8 +761,8 @@ equal the total MPI ranks requested. Here is the ``eddyNekNek.sess`` example:
    inside/inside:1;
    outside/outside:1;
 
-.. tip::                                                                        
-                                                                                
+.. tip::
+
    Using a subfolder per case is optional but recommended. On HPC systems, try
    to size each session in units of a node. For example, if a node has 4 GPUs,
    it’s often best to make each session’s MPI ranks a multiple of 4.

--- a/source/problem_setup/case.rst
+++ b/source/problem_setup/case.rst
@@ -195,6 +195,7 @@ Mesh Parameters
    ``boundaryIDMapFluid``,"``<int>, <int>, ...``", "Required for conjugate heat transfer cases |br| See :ref:`boundary conditions<boundary_conditions>` for details"
    ``connectivityTol``,"``<float>``","Specifies mesh tolerance for partitioner |br| Default = ``0.2``"
    ``file``,"``""<string>""``","Optional name of mesh (``.re2``) file |br| Default is ``<case>.re2``"
+   ``hrefine``,"``<int>, ...``", "Number of splits per direction along an element |br| See :ref:`meshing_hrefine` for details."
 
 
 .. _sec:field_settings:

--- a/source/problem_setup/case.rst
+++ b/source/problem_setup/case.rst
@@ -709,7 +709,7 @@ There are three main limitations for the *nekRS* mesh:
 
 * **3D hex only**: meshes must be hexahedral and three-dimensional.
 * **Contiguous boundary IDs**: face boundary IDs must be 1, 2, 3, … without gaps.
-* **Element types**: supported are HEX8 and HEX20.
+* **Element types**: the main supported types are HEX8 and HEX20.
 
 .. tip::
 

--- a/source/problem_setup/initial_conditions.rst
+++ b/source/problem_setup/initial_conditions.rst
@@ -6,7 +6,7 @@ Initial conditions
 Specification in ``.udf`` File
 -------------------------------
 
-The initial conditions are specified in ``UDF_Setup()`` routine in :ref:`udf_functions` file.
+The initial conditions are specified in ``UDF_Setup()`` routine in :ref:`udf_file` file.
 The following minimal example code snippet sets initial conditions for all three components of velocity, temperature and two passive scalars.
 
 .. code-block::
@@ -43,7 +43,7 @@ It is essential to perform initialization only if ``platform->options.getArgs("R
 ``U, temp, ps1, ps2`` are temporary array ``std::vector`` containers declared on host memory to assign initial conditions. 
 The call ``xyzHost()`` returns the ``x,y,z`` coordinate arrays which may be used to assign spatially varying initial conditions as shown above.
 Finally, the host arrays must be copied into device arrays, ``nrs->fluid->o_U`` and ``nrs->scalar->o_solution`` using ``copyFrom`` calls for initial conditions to be made available for subsequent simulation.
-Note that the scalar identifiers ``"temperature"``, ``"ps1"`` and ``"ps2"`` must be identical to the string declared in the :ref:`General Section <sec:generalpars>` in the ``.par`` file (see :ref:`Parameter file section for details <parameter_file>`)
+Note that the scalar identifiers ``"temperature"``, ``"ps1"`` and ``"ps2"`` must be identical to the string declared in the :ref:`General Section <sec:generalpars>` in the ``.par`` file (see :ref:`Parameter file section for details <par_file>`)
 
 Restarting from Field File
 -------------------------------

--- a/source/problem_setup/meshing.rst
+++ b/source/problem_setup/meshing.rst
@@ -17,6 +17,8 @@ This part of the documentation covers some simple examples that illustrate how t
 aforementioned tools, along with a basic overview of the `mesh_t` struct that is commonly used
 in NekRS to perform operations such as modifying the mesh and setting boundary conditions.
 
+.. _meshing_nek5000_tools:
+
 Using Nek5000 Meshing Tools
 ---------------------------
 
@@ -75,6 +77,12 @@ Instead, the number of elements listed in the new ``.rea`` file will be negative
 To use ``reatore2``, simply compile it using ``./maketools reatore2`` as discussed for other meshing utilities like ``genbox``. Launch it from the terminal, and simply enter the name of the ``rea`` file, followed by the desired name for the ``re2`` file.
 
 
+.. _meshing_convert:
+
+Convert From Other Mesh Format
+------------------------------
+
+------------------
 Using ``gmsh2nek``
 ------------------
 Prior to using ``gmsh2nek``, it is recommended you compile it using a script that is already

--- a/source/problem_setup/meshing.rst
+++ b/source/problem_setup/meshing.rst
@@ -312,6 +312,13 @@ Dynamic mesh movement is possible using the moving mesh solver based on the Arbi
 mesh deformation diffusion parameter which controls the spatial blending of the deformation into the entire domain from the moving mesh boundary. For more details, consult the ``mv_cyl`` example. Apart from the ALE solver, the user has the option to control
 the mesh deformation themselves using ``solver = user`` in the ``[MESH]`` block, but it becomes the user's responsibility to account for the effects of the mesh movement on the physics of the fluid and any scalars being simulated.
 
+.. _meshing_hrefine:
+
+*h* Refinement
+--------------
+
+*TODO*
+
 Miscellaneous Tips
 ------------------
 

--- a/source/problem_setup/meshing.rst
+++ b/source/problem_setup/meshing.rst
@@ -112,6 +112,8 @@ This tool can also create a conjugate heat transfer mesh using two conformal mes
 further information on setting up sidesets and boundary conditions, see the section on `applying boundary conditions <Sidesets and applying boundary conditions>`__
 
 
+.. _meshing_cht:
+
 Conjugate Heat Transfer
 -----------------------
 
@@ -199,40 +201,41 @@ the ``mesh`` object, without any differentiation between whether that ``mesh`` o
 ``nrs`` or ``nrs->cds``.
 
 .. table:: Important ``mesh_t`` members
-  :name:  mesh_data
-================== ============================ ================== =================================================
-Variable Name      Size                         Host or Device?           Meaning
-================== ============================ ================== =================================================
-``comm``           1                            Host               MPI communicator
-``device``         1                            Host               backend device
-``dim``            1                            Host               spatial dimension of mesh
-``elementInfo``    ``Nelements``                Host               phase of element (0 = fluid, 1 = solid)
-``EToB``           ``Nelements * Nfaces``       Both               mapping of elements to type of boundary condition
-``N``              1                            Host               polynomial order for each dimension
-``NboundaryFaces`` 1                            Host               *total* number of faces on a boundary (rank sum)
-``Nelements``      1                            Host               number of local elements owned by current process
-``Nfaces``         1                            Host               number of faces per element
-``Nfp``            1                            Host               number of quadrature points per face
-``Np``             1                            Host               number of quadrature points per element
-``rank``           1                            Host               parallel process rank
-``size``           1                            Host               size of MPI communicator
-``Nfields``        1                            Host               Number of fields passed to the PDE solver
-``cht``            1                            Host               conjugate heat transfer status (0 = off, 1 = on)
-``vmapM``          ``Nelements * Nfaces * Nfp`` Both               quadrature point index for faces on boundaries
-``x``              ``Nelements * Np``           Both               :math:`x`-coordinates of physical quadrature points
-``y``              ``Nelements * Np``           Both               :math:`y`-coordinates of physical quadrature points
-``z``              ``Nelements * Np``           Both               :math:`z`-coordinates of physical quadrature points
-``Nvgeo``          ``<chk>``                    <chk>              Volumetric geometric factors
-``Nggeo``          ``<chk>``                    <chk>              Second-order volumetric geometric factors
-``vertexNodes``    ``<chk>``                    <chk>              Vertex nodes' indices
-``edgeNodes``      ``<chk>``                    <chk>              Edge nodes' indices
-``edgeNodes``      ``<chk>``                    <chk>              List of element reference interpolation nodes on element faces
-``o_LMM``          ``<chk>``                    Device             Lumped mass matrix
-``U``              ``Nelements*Np``             Both               Mesh velocity (often used with ALE solver)
-``D``              ``Nelements*Np``             Both               1D Differentiation matrix
-``o_vgeo``         ``<chk>``                    Device             Volume geometric factors
-``o_sgeo``         ``<chk>``                    Device             Surface geometric factors
-================== ============================ ================== =================================================
+   :name:  mesh_data
+
+   ================== ============================ ================== =================================================
+   Variable Name      Size                         Host or Device?           Meaning
+   ================== ============================ ================== =================================================
+   ``comm``           1                            Host               MPI communicator
+   ``device``         1                            Host               backend device
+   ``dim``            1                            Host               spatial dimension of mesh
+   ``elementInfo``    ``Nelements``                Host               phase of element (0 = fluid, 1 = solid)
+   ``EToB``           ``Nelements * Nfaces``       Both               mapping of elements to type of boundary condition
+   ``N``              1                            Host               polynomial order for each dimension
+   ``NboundaryFaces`` 1                            Host               *total* number of faces on a boundary (rank sum)
+   ``Nelements``      1                            Host               number of local elements owned by current process
+   ``Nfaces``         1                            Host               number of faces per element
+   ``Nfp``            1                            Host               number of quadrature points per face
+   ``Np``             1                            Host               number of quadrature points per element
+   ``rank``           1                            Host               parallel process rank
+   ``size``           1                            Host               size of MPI communicator
+   ``Nfields``        1                            Host               Number of fields passed to the PDE solver
+   ``cht``            1                            Host               conjugate heat transfer status (0 = off, 1 = on)
+   ``vmapM``          ``Nelements * Nfaces * Nfp`` Both               quadrature point index for faces on boundaries
+   ``x``              ``Nelements * Np``           Both               :math:`x`-coordinates of physical quadrature points
+   ``y``              ``Nelements * Np``           Both               :math:`y`-coordinates of physical quadrature points
+   ``z``              ``Nelements * Np``           Both               :math:`z`-coordinates of physical quadrature points
+   ``Nvgeo``          ``<chk>``                    <chk>              Volumetric geometric factors
+   ``Nggeo``          ``<chk>``                    <chk>              Second-order volumetric geometric factors
+   ``vertexNodes``    ``<chk>``                    <chk>              Vertex nodes' indices
+   ``edgeNodes``      ``<chk>``                    <chk>              Edge nodes' indices
+   ``edgeNodes``      ``<chk>``                    <chk>              List of element reference interpolation nodes on element faces
+   ``o_LMM``          ``<chk>``                    Device             Lumped mass matrix
+   ``U``              ``Nelements*Np``             Both               Mesh velocity (often used with ALE solver)
+   ``D``              ``Nelements*Np``             Both               1D Differentiation matrix
+   ``o_vgeo``         ``<chk>``                    Device             Volume geometric factors
+   ``o_sgeo``         ``<chk>``                    Device             Surface geometric factors
+   ================== ============================ ================== =================================================
 
 
 The second most important structure is ``bcData``. It is often referred to in the ``oudf`` kernels to set boundary conditions.
@@ -241,26 +244,26 @@ on a given boundary, setting these values appropriately for each point. The foll
 of this structure mean.
 
 .. table:: Important ``bcData`` members
-  :name:  bcData_members
+   :name:  bcData_members
 
-===================== =======================================================
-Variable Name                Meaning
-===================== =======================================================
-``idM``                Element's mesh ID (?)
-``fieldOffset``        Size of a field (offset for a given component)
-``id``                 Sideset ID
-``time``               Current time
-''x/y/z``              X/Y/Z coordinates
-``nx/ny/nz``           X/Y/Z normals
-``t1x/t1y/t1z``        X/Y/Z tangents
-``t2x/t2y/t2z``        X/Y/Z bitangents
-``p/u/v/w``            Pressure and the 3 velocity components
-``scalarID``           ID of the scalar as per the ``par`` file 
-``s``                  Scalar value
-``flux``               Flux value for flux BC
-``meshu/meshv/meshw``  Mesh velocity components (used in ALE framework)
-``trans/diff``         Mesh transport/diffusion coefficients (ALE framework)
-===================== =======================================================
+   ===================== =======================================================
+   Variable Name                Meaning
+   ===================== =======================================================
+   ``idM``                Element's mesh ID (?)
+   ``fieldOffset``        Size of a field (offset for a given component)
+   ``id``                 Sideset ID
+   ``time``               Current time
+   ''x/y/z``              X/Y/Z coordinates
+   ``nx/ny/nz``           X/Y/Z normals
+   ``t1x/t1y/t1z``        X/Y/Z tangents
+   ``t2x/t2y/t2z``        X/Y/Z bitangents
+   ``p/u/v/w``            Pressure and the 3 velocity components
+   ``scalarID``           ID of the scalar as per the ``par`` file
+   ``s``                  Scalar value
+   ``flux``               Flux value for flux BC
+   ``meshu/meshv/meshw``  Mesh velocity components (used in ALE framework)
+   ``trans/diff``         Mesh transport/diffusion coefficients (ALE framework)
+   ===================== =======================================================
 
 
 

--- a/source/problem_setup/models.rst
+++ b/source/problem_setup/models.rst
@@ -3,11 +3,11 @@
 Models and Source Terms
 =======================
 
-With the exception of :term:`LES` modelling, the :ref:`User-Defined Host Functions (.udf) <udf_functions>` file in NekRS provides the necessary and sufficient interface to load most of the physics models (and postprocessing capabilities).
+With the exception of :term:`LES` modelling, the :ref:`User-Defined Host Functions (.udf) <udf_file>` file in NekRS provides the necessary and sufficient interface to load most of the physics models (and postprocessing capabilities).
 For instance, the :ref:`RANS <rans_models>` and :ref:`lowMach compressible <low_mach>` models available in nekRS are loaded by including corresponding header files in ``.udf`` and by calling the appropriate functions from the standard functions in ``.udf``.
 Appropriate boundary conditions for the momentum and scalar transport equations are specified in the :ref:`okl block <okl_block>` (or  in the included ``.oudf`` file).
 Further, any custom source terms that may need to be added to the momentum or scalar equations are also interfaced through the ``.udf`` file.
-Before proceeding it is, therefore, highly recommended that users familiarize themselves with all components of :ref:`.udf file <udf_functions>`. 
+Before proceeding it is, therefore, highly recommended that users familiarize themselves with all components of :ref:`.udf file <udf_file>`.
 
 Turbulence models
 -----------------
@@ -134,7 +134,7 @@ RANS models
 
 .. Note::
   RANS model requires two passive scalar fields which must be specified in control parameters ``(.par)`` file.
-  For details on how to setup the ``.par`` file, refer to the section on :ref:`.par file <parameter_file>` and also
+  For details on how to setup the ``.par`` file, refer to the section on :ref:`.par file <par_file>` and also
   refer :ref:`RANS Channel tutorial <tutorial_rans>` for specific example of ``.par`` file setup for :term:`RANS`
   simulation
 
@@ -235,7 +235,7 @@ The ``updateProperties()`` call computes the diffusion coefficients for the mome
 
   ``updateProperties()`` also computes the eddy viscosity, :math:`\mu_t`, required in the above diffusion coefficients.
   If the user desires to extract :math:`\mu_t` array, say for post-processing purpose, it can be accessed as follows in the ``.udf`` file:
- ``auto o_mue_t = RANSktau::o_mue_t();``
+  ``auto o_mue_t = RANSktau::o_mue_t();``
 
 The ``updateSourceTerms()`` call computes all source terms on the right hand side of the :math:`k` and :math:`\tau` transport equations, which are, 
 
@@ -248,7 +248,7 @@ The above calls will, therefore, update the diffusion properties and source term
 
 The final necessary step in the model setup for the :math:`k`-:math:`\tau` :term:`RANS` model is the specification of the boundary conditions for the :math:`k` and :math:`\tau` transport equations. 
 As explained in the :ref:`RANS theory <rans_models>` section, the wall boundary condition for both :math:`k` and :math:`\tau` equations are zero.
-These must be explicitly assigned in the :ref:`okl block <okl_block>` section of ``.udf`` file,  
+These must be explicitly assigned in the :ref:`okl block <okl_block>` section of ``.udf`` file,
 
 .. code-block:: cpp
 
@@ -267,10 +267,10 @@ These must be explicitly assigned in the :ref:`okl block <okl_block>` section of
 
 .. warning::
 
- It is highly recommended to familiarize with :ref:`okl block <okl_block>` for proper boundary specification. 
- The above example assumes that the computational domain has no inlet boundaries. In case there are inlet boundaries present, they will also have Dirichlet type boundary condition for the :math:`k` and :math:`\tau` transport equations and it will be necessary to differentiate the value of :math:`k` and :math:`\tau` at the walls (zero) from those at the inlet (problem dependent).
- This is done using ``bc->id`` identifier in the :term:`okl block`. 
- See :ref:`boundary conditions section <boundary_conditions>` for usage details on how to specify boundary conditions.
+  It is highly recommended to familiarize with :ref:`okl block <okl_block>` for proper boundary specification.
+  The above example assumes that the computational domain has no inlet boundaries. In case there are inlet boundaries present, they will also have Dirichlet type boundary condition for the :math:`k` and :math:`\tau` transport equations and it will be necessary to differentiate the value of :math:`k` and :math:`\tau` at the walls (zero) from those at the inlet (problem dependent).
+  This is done using ``bc->id`` identifier in the :ref:`okl_block`.
+  See :ref:`boundary conditions section <boundary_conditions>` for usage details on how to specify boundary conditions.
   
 .. _lowmach_model:
 
@@ -390,7 +390,7 @@ An example for ideal gas assumption is shown below.
 
 ``nrs->fluid->o_prop`` stores the fluid viscosity for all GLL points followed by density, while ``nrs->scalar->o_prop`` stores the diffusivity followed by the product of density and specific heat capacity at constant pressure.
 Corresponding array offsets are, therefore, required by ``fillProp`` to identify the locations where each property is stored.
-``nrs->fluid->fieldOffset`` (``uOffset``) is the total number of GLL points in the fluid sub-domain, while the ``nrs->scalar->fieldOffset()`` (``sOffset``) returns the total number of GLL points in the temperature sub-domain. 
+``nrs->fluid->fieldOffset`` (``uOffset``) is the total number of GLL points in the fluid sub-domain, while the ``nrs->scalar->fieldOffset()`` (``sOffset``) returns the total number of GLL points in the temperature sub-domain.
 
 .. note::
 
@@ -479,8 +479,8 @@ while for ideal gas it is,
 
 
 .. warning::
-  
-  In case of simulations involving multiple species (e.g., reactive flows), ``lowMach::qThermalSingleComponent`` is not valid. 
+
+  In case of simulations involving multiple species (e.g., reactive flows), ``lowMach::qThermalSingleComponent`` is not valid.
   A custom user routine will be required to account for divergence contribution from all species
 
 .. _source_terms:
@@ -489,7 +489,7 @@ Custom Source Terms
 --------------------
 
 NekRS offers the user the option to add custom source terms in ``.udf`` file.
-While the specific construction of the kernels for the user defined source terms will be problem dependent, the following section describes the essential components for building custom source terms for the momenutm and scalar transport equations. 
+While the specific construction of the kernels for the user defined source terms will be problem dependent, the following section describes the essential components for building custom source terms for the momenutm and scalar transport equations.
 
 Momentum Equation
 """""""""""""""""

--- a/source/problem_setup/postprocessing.rst
+++ b/source/problem_setup/postprocessing.rst
@@ -8,7 +8,7 @@ Postprocessing
 Once a case has been setup correctly so it can be run without errors, you may want 
 to modify the postprocessing to of the simulation output. By default, NekRS will
 output a basic set of data according to frequency set in the ``writeInterval`` of
-the :ref:`parameter_file` which can subsequently be viewed through a visualization
+the :ref:`par_file` which can subsequently be viewed through a visualization
 tool such as Paraview or Visit. However, additional data or derived values can
 be extracted by setting up User Defined outputs using the ``UDF_ExecuteStep``
 function of the ``.udf`` file.
@@ -74,7 +74,7 @@ Legacy Averaging Method
 
 When running a high fidelity case with DNS or LES turbulence models, it is often necessary to time-average the solution fields to extract meaningful quantities.
 This may sometimes even be useful for a RANS case as well.
-*NekRS* provides in-built routines that can be embedded in :ref:`udf_functions` to do run-time averaging and write relevant field files. 
+*NekRS* provides in-built routines that can be embedded in :ref:`udf_file` to do run-time averaging and write relevant field files. 
 These are included in ``tavg`` plugin and made available in ``udf`` file by including the ``tavg.hpp`` header file at the top of ``.udf``.
 The minimal structure in ``.udf`` for performing time averaging is as follows:
 

--- a/source/problem_setup/properties.rst
+++ b/source/problem_setup/properties.rst
@@ -6,8 +6,8 @@ Physical properties
 Constant Properties
 -------------------
 
-Constant physical properties, including transport and diffusion coefficients, for all equations are specified in the :ref:`Parameter file <parameter_file>` under respective :ref:`field sections <sec:field_settings>`.
-Consider the following template for a :ref:`non-dimensional <_nondimensional_eqs>` case setup:
+Constant physical properties, including transport and diffusion coefficients, for all equations are specified in the :ref:`Parameter file <par_file>` under respective :ref:`field sections <sec:field_settings>`.
+Consider the following template for a :ref:`non-dimensional <nondimensional_eqs>` case setup:
 
 .. code-block::
 
@@ -42,7 +42,7 @@ For the case where ``FOO`` is temperature field, the transport coefficient is th
 Conjugate Heat Transfer Setup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For :ref:`conjugate heat transfer <conjugate_heat_transfer>` cases *NekRS* provides a convenient way of defining both fluid and solid properties for the temperature equation in the :ref:`Parameter file <parameter_file>` as shown,
+For :ref:`conjugate heat transfer <conjugate_heat_transfer>` cases *NekRS* provides a convenient way of defining both fluid and solid properties for the temperature equation in the :ref:`Parameter file <par_file>` as shown,
 
 .. code-block:: 
 

--- a/source/problem_setup/running.rst
+++ b/source/problem_setup/running.rst
@@ -11,7 +11,7 @@ Native Running
 
 To run *NekRS* natively from the directory containing the :ref:`case`, use the following general command
 
-.. code-block::
+.. code-block:: bash
 
     mpirun -np <number of MPI tasks> nekrs --setup <par|sess file> [options]
 
@@ -22,6 +22,7 @@ Below are the command line options/argument that can be used to further modifiy 
 .. csv-table:: Command line options to run *NekRS*
    :widths: 20,40,40,10
    :header: Command line argument, Options, Description,Required
+   :class: tall
 
    ``--help``,"None |br| ``par`` |br| ``env``", "Prints summary of available command line arguments |br| Prints summary of :ref:`Parameter file <par_file>` sections and keys |br| Prints list of *NekRS* enviorenment variables","No"
    ``--setup``,``par`` file |br| ``sess`` file, "Name of ``.par`` file of the case |br| Name of ``.sess`` file (NekNek)","Yes"
@@ -47,3 +48,47 @@ Running on HPC Systems
 ----------------------
 
 Specific scripts and instructions for running on specific HPC systems can be found `in nekRS_HPCsupport Github repository <https://github.com/Nek5000/nekRS_HPCsupport>`_
+
+
+.. _nekrs_signal:
+
+Runtime Control with Signals
+----------------------------
+
+A signal is a small, asynchronous message the OS sends to a process to request
+an action. Examples include ``SIGTERM`` (polite terminate), ``SIGSTOP`` (suspend),
+and ``SIGKILL`` (force kill). *NekRS* installs handlers for specific signals
+(e.g., ``SIGUSR1``/``SIGUSR2``) to perform runtime tasks. You can map which
+signals trigger which actions via environment variables (see ``nrsman env``):
+
+.. csv-table:: Signal-related environment variables for *NekRS*
+   :widths: 20,20,60
+   :header: Variable,Value,Description
+   :class: tall
+
+   "``NEKRS_SIGNUM_BACKTRACE``","<int>","Signal number to trigger stack trace"
+   "``NEKRS_SIGNUM_TERM``","<int>","Signal number to exit gracefully. |br| Treat the *next* timestep as the final step. If ``checkpointInterval`` > 0 in ``.par``, write a checkpoint"
+   "``NEKRS_SIGNUM_UPD``","<int>","Signal number to process update (trigger) file"
+
+.. note::
+
+   Systems differ slightly. Check which numbers correspond to which signals on
+   your terminal with ``kill -l``, ``kill -l SIGUSR2``, or the manuals
+   (``man 7 signal``). We suggest using catchable signals like ``SIGUSR1``/``SIGUSR2``.
+
+Suppose ``SIGUSR2`` is 12 on your system. Export the mapping before running *NekRS*
+with ``export NEKRS_SIGNUM_BACKTRACE=12``. Then, at runtime, send the signal to
+produce per-rank backtraces (useful when a simulation hangs):
+
+.. code-block:: bash
+
+   # by pid (process id, from "top" or "ps aux")
+   kill -12 <pid>
+
+   # by name
+   pkill -12 nekrs
+   pkill -USR2 nekrs
+
+   # On HPC using slurm scheduler
+   scancel -s USR2 <job id>
+

--- a/source/problem_setup/running.rst
+++ b/source/problem_setup/running.rst
@@ -47,8 +47,58 @@ A number of scripts ship with *NekRS* itself and are located in the ``$NEKRS_HOM
 Running on HPC Systems
 ----------------------
 
-Specific scripts and instructions for running on specific HPC systems can be found `in nekRS_HPCsupport Github repository <https://github.com/Nek5000/nekRS_HPCsupport>`_
+Specific scripts and instructions for running on specific HPC systems can be
+found in `nekRS_HPCsupport Github repository <https://github.com/Nek5000/nekRS_HPCsupport>`_.
+After installing `nekRS`, clone this repository for the latest scripts:
 
+.. code-block:: bash
+
+   git clone https://github.com/Nek5000/nekRS_HPCsupport
+   cd nekRS_HPCsupport
+
+With ``NEKRS_HOME`` pointing to your nekRS installation, run:
+
+.. code-block:: bash
+
+   ./install.sh
+
+The HPC scripts will be installed into ``$NEKRS_HOME/bin`` with a lower case
+machine-name suffix. For example, ``$NEKRS_HOME/bin/nrsqsub_frontier``.
+A typical usage looks like this:
+
+.. code-block:: bash
+
+   PROJ_ID=<project> ./nrsqsub_frontier <case> <#nodes> <hh:mm>
+
+- ``PROJ_ID``: your allocation/account
+- ``case``: case name, `.par` or `.sess` file
+- ``#nodes``: number of nodes
+- ``hh:mm``: walltime (hours:minutes).
+
+For example, this requests to run 1 node with 30 mins on Frontier:
+
+.. code-block:: bash
+
+   PROJ_ID=ABC123 ./nrsqsub_frontier turbPipe.par 1 00:30
+
+You can see the full list of environment variables via ``--help``:
+
+.. code-block:: none
+
+   $ ./nrsqsub_frontier --help
+
+   Usage: [<env-var>] $0 <par or sess file> <number of compute nodes> <hh:mm>
+
+   env-var                 Values(s)   Description / Comment
+   ------------------------------------------------------------------------------------
+   NEKRS_HOME              string      path to installation
+   PROJ_ID                 string
+   QUEUE                   string
+   CPUONLY                 0/1         backend=serial
+   RUN_ONLY                0/1         skip pre-compilation
+   BUILD_ONLY              0/1         run pre-compilation only
+   FP32                    0/1         run solver in single precision
+   OPT_ARGS                string      optional arguements e.g. "--cimode 1 --debug"
 
 .. _nekrs_signal:
 

--- a/source/problem_setup/running.rst
+++ b/source/problem_setup/running.rst
@@ -23,7 +23,7 @@ Below are the command line options/argument that can be used to further modifiy 
    :widths: 20,40,40,10
    :header: Command line argument, Options, Description,Required
 
-   ``--help``,"None |br| ``par`` |br| ``env``", "Prints summary of available command line arguments |br| Prints summary of :ref:`Parameter file <parameter_file>` sections and keys |br| Prints list of *NekRS* enviorenment variables","No"
+   ``--help``,"None |br| ``par`` |br| ``env``", "Prints summary of available command line arguments |br| Prints summary of :ref:`Parameter file <par_file>` sections and keys |br| Prints list of *NekRS* enviorenment variables","No"
    ``--setup``,``par`` file |br| ``sess`` file, "Name of ``.par`` file of the case |br| Name of ``.sess`` file (NekNek)","Yes"
    ``--build-only``,"None |br| ``#procs``","Runs JIT compilation for ``np`` procs |br| Runs JIT compilation for specified number of processors","No"
    ``--cimode``,"``<id>``","Runs *NekRS* in CI mode corresponding to specified ``<id>``","No"

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -227,6 +227,8 @@ Let’s walk through some useful batch scripts provided by *NekRS*:
 - ``nrsman env`` lists useful environment variables for *NekRS*
 - ``nrsman par`` details all options and settings for the *NekRS* ``.par`` case file
 
+.. _qstart_vis:
+
 -----------------------------
 Visualization
 -----------------------------

--- a/source/theory.rst
+++ b/source/theory.rst
@@ -256,7 +256,7 @@ The resulting governing equations for ideal gas assumption, thus, are,
 RANS Models
 -----------
 
-For turbulence modeling :term:`nekRS` offers the two-equation :math:`k`-:math:`\tau` :term:`RANS` model [Tombo2025]_ and its :term:`SST` and :term:`DES` variants [Kumar2024]_.
+For turbulence modeling *nekRS* offers the two-equation :math:`k`-:math:`\tau` :term:`RANS` model [Tombo2025]_ and its :term:`SST` and :term:`DES` variants [Kumar2024]_.
 Linear two-equation RANS models rely on the Bousinessq approximation which relates the Reynolds stress tensor to the mean strain rate, :math:`\boldsymbol{\underline {S}}`, linearly through eddy viscosity.
 The time-averaged momentum equation is given as,
 

--- a/source/tutorials/fdlf.rst
+++ b/source/tutorials/fdlf.rst
@@ -72,7 +72,7 @@ Instructions for installation and setting environment can be found in :ref:`Quic
 
 Before running the case, you will need the mesh generation tool ``genbox``.
 These tools are not packaged with *NekRS* but are available with *Nek5000*. 
-Please follow the instructions in the :ref:`Building the Nek5000 Tool Scripts <scripts>` section to obtain and build this tool.
+Please follow the instructions in the :ref:`Building the Nek5000 Tool Scripts <nek5000_tools>` section to obtain and build this tool.
 
 Mesh Generation
 _______________
@@ -97,7 +97,7 @@ The temperature boundary conditions in the x-direction are a standard Dirichlet 
 In the y-direction the temperature boundary conditions are an insulated condition with zero gradient at :math:`y_{min}` and a constant heat flux at :math:`y_{max}`.
 The z direction boundary conditions are periodic at both :math:`z_{min}` and :math:`z_{max}`.
 
-Note that the boundary conditions specified with lower case letters must have values assigned in relevant functions in the :ref:`udf <udf_functions>` file, which will be shown later in this tutorial (see :ref:`bc_ic_udf`).
+Note that the boundary conditions specified with lower case letters must have values assigned in relevant functions in the :ref:`udf <udf_file>` file, which will be shown later in this tutorial (see :ref:`bc_ic_udf`).
 Now we can generate the mesh with:
 
 .. code-block:: console
@@ -122,7 +122,7 @@ be renamed to ``fdlf.re2``:
 Control parameters file (.par)
 ______________________________
 
-The control parameters for any case are given in the :ref:`par <parameter_file>` file.
+The control parameters for any case are given in the :ref:`par <par_file>` file.
 For this case, create a new file called ``fdlf.par`` with the following:
 
 .. literalinclude:: fdlf/fdlf.par
@@ -141,7 +141,7 @@ This provides an easy way of passing data to *NekRS* that can later be used thro
 Additionally, like all values specified in the ``.par`` file, they can be changed without the need to recompile *NekRS*.
 
 The above case is run with a polynomial order of 5 and upto :math:`t=1s`, as specified using ``endTime`` key.
-Details on the other keys in the ``.par`` can be found :ref:`here <parameter_file>`.
+Details on the other keys in the ``.par`` can be found :ref:`here <par_file>`.
 
 User-Defined Host Functions File (.udf)
 _______________________________________
@@ -268,7 +268,7 @@ It is left empty for this case.
    :language: c++
    :lines: 67-69
 
-For more information on the ``.udf`` file and the available subroutines see :ref:`here <udf_functions>`.
+For more information on the ``.udf`` file and the available subroutines see :ref:`here <udf_file>`.
 
 .. _exact_sol_udf:
 

--- a/source/tutorials/rans_channel.rst
+++ b/source/tutorials/rans_channel.rst
@@ -34,7 +34,7 @@ The mesh is further modified in the ``.udf`` file to refine it near the wall to 
 Control Parameters (.par file)
 ..............................
 
-Details of the structure of the parameter file can be found :ref:`here <parameter_file>`. 
+Details of the structure of the parameter file can be found :ref:`here <par_file>`.
 The parameter file for this case is as follows,
 
 .. literalinclude:: ktauTutorial/channel.par


### PR DESCRIPTION
Go through cases files:
- adjust table height for par keys via CSS
- suppress warning of "@" syntax in mixed cpp/OKL lint.
- add .sess for NekNek
- add table to list all file extensions under "Other Resource"
- prepare LinAlg and opSEM
- rewrite re2, focus on format, remove negatives murmur
- unify `:ref:` format for files. For example, `par_file`, `usr_file`, and `udf_file`.
- complete nekrs.upd
- add signals under problem setup/running
- add Versioning in index.rst
- add h-refine under meshing as TODO, linked from `par/MESH/hrefine`
- add hpc support, and hpc script doc